### PR TITLE
GEOPY-1698: relock conda env on new geoapps-utils

### DIFF
--- a/environments/py-3.10-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.10-linux-64-dev.conda.lock.yml
@@ -4,6 +4,7 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
@@ -18,8 +19,8 @@ dependencies:
   - brotli-python=1.1.0=py310hc6cd4ac_1
   - brunsli=0.1=h9c3ff4c_0
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.32.2=h4bc722e_0
-  - c-blosc2=2.15.0=h6d6b9e4_1
+  - c-ares=1.32.3=h4bc722e_0
+  - c-blosc2=2.15.1=hc57e6cf_0
   - ca-certificates=2024.7.4=hbcca054_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -49,8 +50,8 @@ dependencies:
   - imagecodecs=2024.6.1=py310h51fded0_2
   - imageio=2.34.2=pyh12aca89_0
   - imagesize=1.4.1=pyhd8ed1ab_0
-  - importlib-metadata=8.0.0=pyha770c72_0
-  - importlib_metadata=8.0.0=hd8ed1ab_0
+  - importlib-metadata=8.2.0=pyha770c72_0
+  - importlib_metadata=8.2.0=hd8ed1ab_0
   - iniconfig=2.0.0=pyhd8ed1ab_0
   - isort=5.13.2=pyhd8ed1ab_0
   - jinja2=3.1.4=pyhd8ed1ab_0
@@ -62,13 +63,13 @@ dependencies:
   - ld_impl_linux-64=2.40=hf3520f5_7
   - lerc=4.0.0=h27087fc_0
   - libaec=1.1.3=h59595ed_0
-  - libavif16=1.1.0=h9b56c87_0
+  - libavif16=1.1.1=h9b56c87_0
   - libblas=3.9.0=23_linux64_openblas
   - libbrotlicommon=1.1.0=hd590300_1
   - libbrotlidec=1.1.0=hd590300_1
   - libbrotlienc=1.1.0=hd590300_1
   - libcblas=3.9.0=23_linux64_openblas
-  - libcurl=8.8.0=hca28451_1
+  - libcurl=8.9.1=hdb1bdb2_0
   - libdeflate=1.20=hd590300_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=hd590300_2
@@ -107,7 +108,7 @@ dependencies:
   - packaging=24.1=pyhd8ed1ab_0
   - partd=1.4.2=pyhd8ed1ab_0
   - pillow=10.3.0=py310hebfe307_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - platformdirs=4.2.2=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
   - pthread-stubs=0.4=h36c2ea0_1001
@@ -117,7 +118,7 @@ dependencies:
   - pygments=2.18.0=pyhd8ed1ab_0
   - pylint=3.2.6=pyhd8ed1ab_0
   - pysocks=1.7.1=pyha2e5f31_6
-  - pytest=8.3.1=pyhd8ed1ab_0
+  - pytest=8.3.2=pyhd8ed1ab_0
   - pytest-cov=5.0.0=pyhd8ed1ab_0
   - python=3.10.14=hd12c33a_0_cpython
   - python_abi=3.10=4_cp310
@@ -129,22 +130,22 @@ dependencies:
   - requests=2.32.3=pyhd8ed1ab_0
   - scikit-image=0.20.0=py310h9b08913_1
   - scipy=1.14.0=py310h93e2701_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - snappy=1.2.1=ha2e4443_0
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
   - sphinx=7.4.7=pyhd8ed1ab_0
   - sphinx-autodoc-typehints=2.2.3=pyhd8ed1ab_0
   - sphinx-rtd-theme=2.0.0=hd8ed1ab_0
   - sphinx_rtd_theme=2.0.0=pyha770c72_0
-  - sphinxcontrib-applehelp=1.0.8=pyhd8ed1ab_0
-  - sphinxcontrib-devhelp=1.0.6=pyhd8ed1ab_0
-  - sphinxcontrib-htmlhelp=2.0.6=pyhd8ed1ab_0
+  - sphinxcontrib-applehelp=2.0.0=pyhd8ed1ab_0
+  - sphinxcontrib-devhelp=2.0.0=pyhd8ed1ab_0
+  - sphinxcontrib-htmlhelp=2.1.0=pyhd8ed1ab_0
   - sphinxcontrib-jquery=4.1=pyhd8ed1ab_0
   - sphinxcontrib-jsmath=1.0.1=pyhd8ed1ab_0
-  - sphinxcontrib-qthelp=1.0.8=pyhd8ed1ab_0
+  - sphinxcontrib-qthelp=2.0.0=pyhd8ed1ab_0
   - sphinxcontrib-serializinghtml=1.1.10=pyhd8ed1ab_0
   - svt-av1=2.1.2=hac33072_0
-  - tifffile=2024.7.21=pyhd8ed1ab_0
+  - tifffile=2024.7.24=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
@@ -166,8 +167,8 @@ dependencies:
   - zstandard=0.23.0=py310h64cae3c_0
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-linux-64.conda.lock.yml
+++ b/environments/py-3.10-linux-64.conda.lock.yml
@@ -4,6 +4,7 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
@@ -14,8 +15,8 @@ dependencies:
   - brotli-bin=1.1.0=hd590300_1
   - brunsli=0.1=h9c3ff4c_0
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.32.2=h4bc722e_0
-  - c-blosc2=2.15.0=h6d6b9e4_1
+  - c-ares=1.32.3=h4bc722e_0
+  - c-blosc2=2.15.1=hc57e6cf_0
   - ca-certificates=2024.7.4=hbcca054_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -33,8 +34,8 @@ dependencies:
   - hdf5=1.14.3=nompi_hdf9ad27_105
   - imagecodecs=2024.6.1=py310h51fded0_2
   - imageio=2.34.2=pyh12aca89_0
-  - importlib-metadata=8.0.0=pyha770c72_0
-  - importlib_metadata=8.0.0=hd8ed1ab_0
+  - importlib-metadata=8.2.0=pyha770c72_0
+  - importlib_metadata=8.2.0=hd8ed1ab_0
   - jxrlib=1.1=hd590300_3
   - keyutils=1.6.1=h166bdaf_0
   - krb5=1.21.3=h659f571_0
@@ -43,13 +44,13 @@ dependencies:
   - ld_impl_linux-64=2.40=hf3520f5_7
   - lerc=4.0.0=h27087fc_0
   - libaec=1.1.3=h59595ed_0
-  - libavif16=1.1.0=h9b56c87_0
+  - libavif16=1.1.1=h9b56c87_0
   - libblas=3.9.0=23_linux64_openblas
   - libbrotlicommon=1.1.0=hd590300_1
   - libbrotlidec=1.1.0=hd590300_1
   - libbrotlienc=1.1.0=hd590300_1
   - libcblas=3.9.0=23_linux64_openblas
-  - libcurl=8.8.0=hca28451_1
+  - libcurl=8.9.1=hdb1bdb2_0
   - libdeflate=1.20=hd590300_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=hd590300_2
@@ -86,7 +87,7 @@ dependencies:
   - packaging=24.1=pyhd8ed1ab_0
   - partd=1.4.2=pyhd8ed1ab_0
   - pillow=10.3.0=py310hebfe307_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - pthread-stubs=0.4=h36c2ea0_1001
   - pydantic=2.8.2=pyhd8ed1ab_0
   - pydantic-core=2.20.1=py310h42e942d_0
@@ -98,10 +99,10 @@ dependencies:
   - readline=8.2=h8228510_1
   - scikit-image=0.20.0=py310h9b08913_1
   - scipy=1.14.0=py310h93e2701_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - snappy=1.2.1=ha2e4443_0
   - svt-av1=2.1.2=hac33072_0
-  - tifffile=2024.7.21=pyhd8ed1ab_0
+  - tifffile=2024.7.24=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - toolz=0.12.1=pyhd8ed1ab_0
   - tqdm=4.66.4=pyhd8ed1ab_0
@@ -118,8 +119,8 @@ dependencies:
   - zlib-ng=2.2.1=he02047a_0
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-win-64-dev.conda.lock.yml
+++ b/environments/py-3.10-win-64-dev.conda.lock.yml
@@ -4,8 +4,9 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
-  - _libavif_api=1.1.0=h57928b3_0
+  - _libavif_api=1.1.1=h57928b3_0
   - alabaster=0.7.16=pyhd8ed1ab_0
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - aom=3.9.1=he0c23c2_0
@@ -14,7 +15,7 @@ dependencies:
   - blosc=1.21.6=h85f69ea_0
   - brotli-python=1.1.0=py310h00ffb61_1
   - bzip2=1.0.8=h2466b09_7
-  - c-blosc2=2.15.0=hb461149_1
+  - c-blosc2=2.15.1=hb461149_0
   - ca-certificates=2024.7.4=h56e8100_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -44,8 +45,8 @@ dependencies:
   - imagecodecs=2024.6.1=py310h40cd1a8_2
   - imageio=2.34.2=pyh12aca89_0
   - imagesize=1.4.1=pyhd8ed1ab_0
-  - importlib-metadata=8.0.0=pyha770c72_0
-  - importlib_metadata=8.0.0=hd8ed1ab_0
+  - importlib-metadata=8.2.0=pyha770c72_0
+  - importlib_metadata=8.2.0=hd8ed1ab_0
   - iniconfig=2.0.0=pyhd8ed1ab_0
   - intel-openmp=2024.2.0=h57928b3_980
   - isort=5.13.2=pyhd8ed1ab_0
@@ -56,13 +57,13 @@ dependencies:
   - lcms2=2.16=h67d730c_0
   - lerc=4.0.0=h63175ca_0
   - libaec=1.1.3=h63175ca_0
-  - libavif16=1.1.0=hf4f7b25_0
+  - libavif16=1.1.1=hf4f7b25_0
   - libblas=3.9.0=23_win64_mkl
   - libbrotlicommon=1.1.0=hcfcfb64_1
   - libbrotlidec=1.1.0=hcfcfb64_1
   - libbrotlienc=1.1.0=hcfcfb64_1
   - libcblas=3.9.0=23_win64_mkl
-  - libcurl=8.8.0=hd5e4a3a_1
+  - libcurl=8.9.1=h18fefc2_0
   - libdeflate=1.20=hcfcfb64_0
   - libffi=3.4.2=h8ffe710_5
   - libhwloc=2.11.1=default_h8125262_1000
@@ -96,7 +97,7 @@ dependencies:
   - packaging=24.1=pyhd8ed1ab_0
   - partd=1.4.2=pyhd8ed1ab_0
   - pillow=10.3.0=py310h3e38d90_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - platformdirs=4.2.2=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
   - pthread-stubs=0.4=hcd874cb_1001
@@ -107,7 +108,7 @@ dependencies:
   - pygments=2.18.0=pyhd8ed1ab_0
   - pylint=3.2.6=pyhd8ed1ab_0
   - pysocks=1.7.1=pyh0701188_6
-  - pytest=8.3.1=pyhd8ed1ab_0
+  - pytest=8.3.2=pyhd8ed1ab_0
   - pytest-cov=5.0.0=pyhd8ed1ab_0
   - python=3.10.14=h4de0772_0_cpython
   - python_abi=3.10=4_cp310
@@ -118,23 +119,23 @@ dependencies:
   - requests=2.32.3=pyhd8ed1ab_0
   - scikit-image=0.20.0=py310h1c4a608_1
   - scipy=1.14.0=py310h46043a1_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - snappy=1.2.1=h23299a8_0
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
   - sphinx=7.4.7=pyhd8ed1ab_0
   - sphinx-autodoc-typehints=2.2.3=pyhd8ed1ab_0
   - sphinx-rtd-theme=2.0.0=hd8ed1ab_0
   - sphinx_rtd_theme=2.0.0=pyha770c72_0
-  - sphinxcontrib-applehelp=1.0.8=pyhd8ed1ab_0
-  - sphinxcontrib-devhelp=1.0.6=pyhd8ed1ab_0
-  - sphinxcontrib-htmlhelp=2.0.6=pyhd8ed1ab_0
+  - sphinxcontrib-applehelp=2.0.0=pyhd8ed1ab_0
+  - sphinxcontrib-devhelp=2.0.0=pyhd8ed1ab_0
+  - sphinxcontrib-htmlhelp=2.1.0=pyhd8ed1ab_0
   - sphinxcontrib-jquery=4.1=pyhd8ed1ab_0
   - sphinxcontrib-jsmath=1.0.1=pyhd8ed1ab_0
-  - sphinxcontrib-qthelp=1.0.8=pyhd8ed1ab_0
+  - sphinxcontrib-qthelp=2.0.0=pyhd8ed1ab_0
   - sphinxcontrib-serializinghtml=1.1.10=pyhd8ed1ab_0
   - svt-av1=2.1.2=he0c23c2_0
   - tbb=2021.12.0=hc790b64_3
-  - tifffile=2024.7.21=pyhd8ed1ab_0
+  - tifffile=2024.7.24=pyhd8ed1ab_0
   - tk=8.6.13=h5226925_1
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
@@ -161,8 +162,8 @@ dependencies:
   - zstandard=0.23.0=py310he5e10e1_0
   - zstd=1.5.6=h0ea2cb4_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-win-64.conda.lock.yml
+++ b/environments/py-3.10-win-64.conda.lock.yml
@@ -4,13 +4,14 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
-  - _libavif_api=1.1.0=h57928b3_0
+  - _libavif_api=1.1.1=h57928b3_0
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - aom=3.9.1=he0c23c2_0
   - blosc=1.21.6=h85f69ea_0
   - bzip2=1.0.8=h2466b09_7
-  - c-blosc2=2.15.0=hb461149_1
+  - c-blosc2=2.15.1=hb461149_0
   - ca-certificates=2024.7.4=h56e8100_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -28,8 +29,8 @@ dependencies:
   - hdf5=1.14.3=nompi_h2b43c12_105
   - imagecodecs=2024.6.1=py310h40cd1a8_2
   - imageio=2.34.2=pyh12aca89_0
-  - importlib-metadata=8.0.0=pyha770c72_0
-  - importlib_metadata=8.0.0=hd8ed1ab_0
+  - importlib-metadata=8.2.0=pyha770c72_0
+  - importlib_metadata=8.2.0=hd8ed1ab_0
   - intel-openmp=2024.2.0=h57928b3_980
   - jxrlib=1.1=hcfcfb64_3
   - krb5=1.21.3=hdf4eb48_0
@@ -37,13 +38,13 @@ dependencies:
   - lcms2=2.16=h67d730c_0
   - lerc=4.0.0=h63175ca_0
   - libaec=1.1.3=h63175ca_0
-  - libavif16=1.1.0=hf4f7b25_0
+  - libavif16=1.1.1=hf4f7b25_0
   - libblas=3.9.0=23_win64_mkl
   - libbrotlicommon=1.1.0=hcfcfb64_1
   - libbrotlidec=1.1.0=hcfcfb64_1
   - libbrotlienc=1.1.0=hcfcfb64_1
   - libcblas=3.9.0=23_win64_mkl
-  - libcurl=8.8.0=hd5e4a3a_1
+  - libcurl=8.9.1=h18fefc2_0
   - libdeflate=1.20=hcfcfb64_0
   - libffi=3.4.2=h8ffe710_5
   - libhwloc=2.11.1=default_h8125262_1000
@@ -75,7 +76,7 @@ dependencies:
   - packaging=24.1=pyhd8ed1ab_0
   - partd=1.4.2=pyhd8ed1ab_0
   - pillow=10.3.0=py310h3e38d90_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - pthread-stubs=0.4=hcd874cb_1001
   - pthreads-win32=2.9.1=hfa6e2cd_3
   - pydantic=2.8.2=pyhd8ed1ab_0
@@ -87,11 +88,11 @@ dependencies:
   - rav1e=0.6.6=h975169c_2
   - scikit-image=0.20.0=py310h1c4a608_1
   - scipy=1.14.0=py310h46043a1_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - snappy=1.2.1=h23299a8_0
   - svt-av1=2.1.2=he0c23c2_0
   - tbb=2021.12.0=hc790b64_3
-  - tifffile=2024.7.21=pyhd8ed1ab_0
+  - tifffile=2024.7.24=pyhd8ed1ab_0
   - tk=8.6.13=h5226925_1
   - toolz=0.12.1=pyhd8ed1ab_0
   - tqdm=4.66.4=pyhd8ed1ab_0
@@ -112,8 +113,8 @@ dependencies:
   - zlib-ng=2.2.1=he0c23c2_0
   - zstd=1.5.6=h0ea2cb4_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/py-3.10.conda-lock.yml
+++ b/py-3.10.conda-lock.yml
@@ -20,6 +20,8 @@ metadata:
   channels:
   - url: conda-forge
     used_env_vars: []
+  - url: nodefaults
+    used_env_vars: []
   platforms:
   - win-64
   - linux-64
@@ -28,14 +30,14 @@ metadata:
   - environments/env-python-3.10.yml
 package:
 - name: _libavif_api
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.0-h57928b3_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_0.conda
   hash:
-    md5: 9891589d904ca5e61dd71dca149d43e3
-    sha256: a98d752bdd15cebef6cacddb3f71908d51100a3d3b368bda305374dfc40f2c6d
+    md5: 408ce8730bc562cc4093f42560d05937
+    sha256: 753347a11e1eb2362c60e3a9da4d0f453a889dd33991793b775a6ed430ad9125
   category: main
   optional: false
 - name: _libgcc_mutex
@@ -332,36 +334,37 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.32.2
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.2-h4bc722e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
   hash:
-    md5: 8024af1ee7078e37fa3101c0a0296af2
-    sha256: d1b01f9e3d10b97fd09e19fda0caf9bfad3c884a6b19fb3f654a9aed02a70b58
+    md5: 7624e34ee6baebfc80d67bac76cc9d9d
+    sha256: 3c5a844bb60b0d52d89c3f1bd828c9856417fe33a6102fd8bbd5c13c3351704a
   category: main
   optional: false
 - name: c-blosc2
-  version: 2.15.0
+  version: 2.15.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    zlib-ng: '>=2.2.0,<2.3.0a0'
+    zlib-ng: '>=2.2.1,<2.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.15.0-h6d6b9e4_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.15.1-hc57e6cf_0.conda
   hash:
-    md5: 0dbd746357ef08ceb6c732c391e6a98c
-    sha256: f510ec2e2729c973f519e15c37e001c46020428807c0756abef3388f952fa773
+    md5: 5f84961d86d0ef78851cb34f9d5e31fe
+    sha256: 6b11cae208878fbf621fbc22135a7912fd0ef19301d0b654858ae16b972410dc
   category: main
   optional: false
 - name: c-blosc2
-  version: 2.15.0
+  version: 2.15.1
   manager: conda
   platform: win-64
   dependencies:
@@ -369,12 +372,12 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-    zlib-ng: '>=2.2.0,<2.3.0a0'
+    zlib-ng: '>=2.2.1,<2.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.15.0-hb461149_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.15.1-hb461149_0.conda
   hash:
-    md5: 7ea528c0838a10d2d0702deb7b54fa14
-    sha256: 4847e3f39f41553710ae04a8eebf9078021e22d03c0cb55bb79acdf5719f3628
+    md5: a84e7df0bc9dc85a9e3db6c2870c9dcf
+    sha256: a380bc3f2bbc423fec963e9ab9284eb67deb8d3d67a0676fc3f5ccce8497685c
   category: main
   optional: false
 - name: ca-certificates
@@ -1228,53 +1231,53 @@ package:
   category: dev
   optional: true
 - name: importlib-metadata
-  version: 8.0.0
+  version: 8.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
   hash:
-    md5: 3286556cdd99048d198f72c3f6f69103
-    sha256: e40d7e71c37ec95df9a19d39f5bb7a567c325be3ccde06290a71400aab719cac
+    md5: c261d14fc7f49cdd403868998a18c318
+    sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.0.0
+  version: 8.2.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.0.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
   hash:
-    md5: 3286556cdd99048d198f72c3f6f69103
-    sha256: e40d7e71c37ec95df9a19d39f5bb7a567c325be3ccde06290a71400aab719cac
+    md5: c261d14fc7f49cdd403868998a18c318
+    sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
   category: main
   optional: false
 - name: importlib_metadata
-  version: 8.0.0
+  version: 8.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=8.0.0,<8.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.2.0,<8.2.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
   hash:
-    md5: 5f8c8ebbe6413a7838cf6ecf14d5d31b
-    sha256: f786f67bcdd6debb6edc2bc496e2899a560bbcc970e66727d42a805a1a5bf9a3
+    md5: 0fd030dce707a6654472cf7619b0b01b
+    sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
   category: main
   optional: false
 - name: importlib_metadata
-  version: 8.0.0
+  version: 8.2.0
   manager: conda
   platform: win-64
   dependencies:
-    importlib-metadata: '>=8.0.0,<8.0.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.0.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.2.0,<8.2.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
   hash:
-    md5: 5f8c8ebbe6413a7838cf6ecf14d5d31b
-    sha256: f786f67bcdd6debb6edc2bc496e2899a560bbcc970e66727d42a805a1a5bf9a3
+    md5: 0fd030dce707a6654472cf7619b0b01b
+    sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
   category: main
   optional: false
 - name: iniconfig
@@ -1556,7 +1559,7 @@ package:
   category: main
   optional: false
 - name: libavif16
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1566,18 +1569,18 @@ package:
     libgcc-ng: '>=12'
     rav1e: '>=0.6.6,<1.0a0'
     svt-av1: '>=2.1.2,<2.1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.0-h9b56c87_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.1.1-h9b56c87_0.conda
   hash:
-    md5: ab39000b12375e3a30ee79fea996e3c5
-    sha256: 75b9a97b4a863ad8e3934b7cb2eaefa5c63e0519d6221436d59a8c14c732f982
+    md5: cb7355212240e92dcf9c73cb1f10e4a9
+    sha256: 86318e068dfc1fb66cfd9fc030f53de1e9fb6469243c389483054928981f7a3e
   category: main
   optional: false
 - name: libavif16
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: win-64
   dependencies:
-    _libavif_api: '>=1.1.0,<1.1.1.0a0'
+    _libavif_api: '>=1.1.1,<1.1.2.0a0'
     aom: '>=3.9.1,<3.10.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
     rav1e: '>=0.6.6,<1.0a0'
@@ -1585,10 +1588,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.0-hf4f7b25_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-hf4f7b25_0.conda
   hash:
-    md5: d855d66e7eb655db7d6306995b0a3425
-    sha256: 10c7c4537ec2e5a561e17be99694e58359eb205fbd04372ca787c9841e1eb5b4
+    md5: a75e0a0b9ea8756ffc6b011346576bae
+    sha256: 73e8f40e879e4993be96564e37eba25731196eee63a3cbb56af536746543fc96
   category: main
   optional: false
 - name: libblas
@@ -1722,7 +1725,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.8.0
+  version: 8.9.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1730,30 +1733,30 @@ package:
     libgcc-ng: '>=12'
     libnghttp2: '>=1.58.0,<2.0a0'
     libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.3.1,<4.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.1-hdb1bdb2_0.conda
   hash:
-    md5: b8afb3e3cb3423cc445cf611ab95fdb0
-    sha256: 6b5b64cdcdb643368ebe236de07eedee99b025bb95129bbe317c46e5bdc693f3
+    md5: 7da1d242ca3591e174a3c7d82230d3c0
+    sha256: 0ba60f83709068e9ec1ab543af998cb5a201c8379c871205447684a34b5abfd8
   category: main
   optional: false
 - name: libcurl
-  version: 8.8.0
+  version: 8.9.1
   manager: conda
   platform: win-64
   dependencies:
     krb5: '>=1.21.3,<1.22.0a0'
     libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.9.1-h18fefc2_0.conda
   hash:
-    md5: 88fbd2ea44690c6dfad8737659936461
-    sha256: ebe665ec226672e7e6e37f2b1fe554db83f9fea5267cbc5a849ab34d8546b2c3
+    md5: 099a1016d23baa4f41148a985351a7a8
+    sha256: 024be133aed5f100c0b222761e747cc27a2bdf94af51947ad5f70e88cf824988
   category: main
   optional: false
 - name: libdeflate
@@ -2751,31 +2754,31 @@ package:
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: '24.2'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 6721aef6bfe5937abe70181545dd2c51
+    sha256: 15b480571a7a4d896aa187648cce99f98bac3926253f028f228d2e9e1cf7c1e1
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: '24.2'
   manager: conda
   platform: win-64
   dependencies:
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 6721aef6bfe5937abe70181545dd2c51
+    sha256: 15b480571a7a4d896aa187648cce99f98bac3926253f028f228d2e9e1cf7c1e1
   category: main
   optional: false
 - name: platformdirs
@@ -3043,7 +3046,7 @@ package:
   category: dev
   optional: true
 - name: pytest
-  version: 8.3.1
+  version: 8.3.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -3054,14 +3057,14 @@ package:
     pluggy: <2,>=1.5
     python: '>=3.8'
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b6a3ab8559a42070c6b6c3063faea1ed
-    sha256: 23693df629c43f277b564abfcb321f6d9c4b6153a925ed004be7749bbc09ac3c
+    md5: e010a224b90f1f623a917c35addbb924
+    sha256: 72c84a3cd9fe82835a88e975fd2a0dbf2071d1c423ea4f79e7930578c1014873
   category: dev
   optional: true
 - name: pytest
-  version: 8.3.1
+  version: 8.3.2
   manager: conda
   platform: win-64
   dependencies:
@@ -3072,10 +3075,10 @@ package:
     exceptiongroup: '>=1.0.0rc8'
     tomli: '>=1'
     pluggy: <2,>=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b6a3ab8559a42070c6b6c3063faea1ed
-    sha256: 23693df629c43f277b564abfcb321f6d9c4b6153a925ed004be7749bbc09ac3c
+    md5: e010a224b90f1f623a917c35addbb924
+    sha256: 72c84a3cd9fe82835a88e975fd2a0dbf2071d1c423ea4f79e7930578c1014873
   category: dev
   optional: true
 - name: pytest-cov
@@ -3437,27 +3440,27 @@ package:
   category: main
   optional: false
 - name: setuptools
-  version: 71.0.4
+  version: 72.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ee78ac9c720d0d02fcfd420866b82ab1
-    sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+    md5: e06d4c26df4f958a8d38696f2c344d15
+    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
   category: main
   optional: false
 - name: setuptools
-  version: 71.0.4
+  version: 72.1.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ee78ac9c720d0d02fcfd420866b82ab1
-    sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+    md5: e06d4c26df4f958a8d38696f2c344d15
+    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
   category: main
   optional: false
 - name: snappy
@@ -3561,10 +3564,10 @@ package:
     alabaster: '>=0.7.14,<0.8.dev0'
     babel: '>=2.13'
     docutils: '>=0.20,<0.22'
-    importlib-metadata: '>=6.0'
     pygments: '>=2.17'
     requests: '>=2.30.0'
     snowballstemmer: '>=2.2'
+    importlib-metadata: '>=6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.4.7-pyhd8ed1ab_0.conda
   hash:
     md5: c568e260463da2528ecfd7c5a0b41bbd
@@ -3652,81 +3655,81 @@ package:
   category: dev
   optional: true
 - name: sphinxcontrib-applehelp
-  version: 1.0.8
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 611a35a27914fac3aa37611a6fe40bb5
-    sha256: 710013443a063518d587d2af82299e92ab6d6695edf35a676ac3a0ccc9e3f8e6
+    md5: 9075bd8c033f0257122300db914e49c9
+    sha256: 8ac476358cf26098e3a360b2a9037bd809243f72934c103953e25f4fda4b9f31
   category: dev
   optional: true
 - name: sphinxcontrib-applehelp
-  version: 1.0.8
+  version: 2.0.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 611a35a27914fac3aa37611a6fe40bb5
-    sha256: 710013443a063518d587d2af82299e92ab6d6695edf35a676ac3a0ccc9e3f8e6
+    md5: 9075bd8c033f0257122300db914e49c9
+    sha256: 8ac476358cf26098e3a360b2a9037bd809243f72934c103953e25f4fda4b9f31
   category: dev
   optional: true
 - name: sphinxcontrib-devhelp
-  version: 1.0.6
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d7e4954df0d3aea2eacc7835ad12671d
-    sha256: 63a6b60653ef13a6712848f4b3c4b713d4b564da1dae571893f1a3659cde85f3
+    md5: b3bcc38c471ebb738854f52a36059b48
+    sha256: 6790efe55f168816dfc9c14235054d5156e5150d28546c5baf2ff4973eff8f6b
   category: dev
   optional: true
 - name: sphinxcontrib-devhelp
-  version: 1.0.6
+  version: 2.0.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d7e4954df0d3aea2eacc7835ad12671d
-    sha256: 63a6b60653ef13a6712848f4b3c4b713d4b564da1dae571893f1a3659cde85f3
+    md5: b3bcc38c471ebb738854f52a36059b48
+    sha256: 6790efe55f168816dfc9c14235054d5156e5150d28546c5baf2ff4973eff8f6b
   category: dev
   optional: true
 - name: sphinxcontrib-htmlhelp
-  version: 2.0.6
+  version: 2.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d6f4b617daa8c677f60c06a3a61e2743
-    sha256: ef8a4e783dba8003273622059363ada968009ca36f853c5faa54ea0f2f789fd3
+    md5: e25640d692c02e8acfff0372f547e940
+    sha256: 55e14b77ed786ab6ff752b8d75f8448536f385ed250f432bd408d2eff5ea4a9e
   category: dev
   optional: true
 - name: sphinxcontrib-htmlhelp
-  version: 2.0.6
+  version: 2.1.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d6f4b617daa8c677f60c06a3a61e2743
-    sha256: ef8a4e783dba8003273622059363ada968009ca36f853c5faa54ea0f2f789fd3
+    md5: e25640d692c02e8acfff0372f547e940
+    sha256: 55e14b77ed786ab6ff752b8d75f8448536f385ed250f432bd408d2eff5ea4a9e
   category: dev
   optional: true
 - name: sphinxcontrib-jquery
@@ -3780,29 +3783,29 @@ package:
   category: dev
   optional: true
 - name: sphinxcontrib-qthelp
-  version: 1.0.8
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 179912c661d6aa9fe794e81c854f8d9f
-    sha256: d644031a17b970c89b11ebd6ff56e7dafc71d9096754840e7742e6597238527f
+    md5: d6e5ea5fe00164ac6c2dcc5d76a42192
+    sha256: 7ae639b729844de2ec74dbaf1acccc14843868a82fa46cd2ceb735bc8266af5b
   category: dev
   optional: true
 - name: sphinxcontrib-qthelp
-  version: 1.0.8
+  version: 2.0.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.9'
     sphinx: '>=5'
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 179912c661d6aa9fe794e81c854f8d9f
-    sha256: d644031a17b970c89b11ebd6ff56e7dafc71d9096754840e7742e6597238527f
+    md5: d6e5ea5fe00164ac6c2dcc5d76a42192
+    sha256: 7ae639b729844de2ec74dbaf1acccc14843868a82fa46cd2ceb735bc8266af5b
   category: dev
   optional: true
 - name: sphinxcontrib-serializinghtml
@@ -3874,31 +3877,31 @@ package:
   category: main
   optional: false
 - name: tifffile
-  version: 2024.7.21
+  version: 2024.7.24
   manager: conda
   platform: linux-64
   dependencies:
     imagecodecs: '>=2023.8.12'
     numpy: '>=1.19.2'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.7.21-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.7.24-pyhd8ed1ab_0.conda
   hash:
-    md5: 8788450bcfa8f24f7d2e231351a58938
-    sha256: 54fb685663e052221c38e68d49784f6ea27467ac3a3b41edf37309044b24aea9
+    md5: 5e59c23bd7626e83acf61657cf0512e9
+    sha256: e31137890b9677a0c7f6f8961970a4c052d2bb0f75de80d5a89c95d89e82ad68
   category: main
   optional: false
 - name: tifffile
-  version: 2024.7.21
+  version: 2024.7.24
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.10'
     numpy: '>=1.19.2'
     imagecodecs: '>=2023.8.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.7.21-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tifffile-2024.7.24-pyhd8ed1ab_0.conda
   hash:
-    md5: 8788450bcfa8f24f7d2e231351a58938
-    sha256: 54fb685663e052221c38e68d49784f6ea27467ac3a3b41edf37309044b24aea9
+    md5: 5e59c23bd7626e83acf61657cf0512e9
+    sha256: e31137890b9677a0c7f6f8961970a4c052d2bb0f75de80d5a89c95d89e82ad68
   category: main
   optional: false
 - name: tk
@@ -4484,38 +4487,34 @@ package:
   manager: pip
   platform: linux-64
   dependencies:
-    pillow: '>=10.3.0,<10.4.0'
     geoh5py: 0.10.0a1
-    h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+  url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   hash:
-    sha256: e0cc6f5178fec820647f088f348a2f8db81c58a2
+    sha256: 2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+    url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   optional: false
 - name: geoapps-utils
   version: 0.4.0a1
   manager: pip
   platform: win-64
   dependencies:
-    pillow: '>=10.3.0,<10.4.0'
     geoh5py: 0.10.0a1
-    h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+  url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   hash:
-    sha256: e0cc6f5178fec820647f088f348a2f8db81c58a2
+    sha256: 2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+    url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -4526,13 +4525,13 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   hash:
-    sha256: 21ce81d279c206ce0a279377168ce50e0a35d3d2
+    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -4543,11 +4542,11 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   hash:
-    sha256: 21ce81d279c206ce0a279377168ce50e0a35d3d2
+    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   optional: false


### PR DESCRIPTION
**GEOPY-1698 - relock conda env of repos to use fixed revision of geoapps-utils**
