### PR TITLE
GEOPY-1712: Use Ruff instead of black and isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,38 @@ channels = ['conda-forge']
 h5py = ">=3.2.1, <4.0.0"  # from geoh5py
 Pillow = ">=10.3.0, <10.4.0"  # from geoh5py
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+target-version = "py310"
 
-[tool.black]
-# defaults are just fine
+[tool.ruff.lint]
+ignore = [
+    "RUF005",  # collection-literal-concatenation - wrong suggestion with numpy arrays
+]
+select = [
+    "A",  # flake8-builtins
+    "B",  # flake8-bugbear
+    "B006",  # Do not use mutable data structures for argument defaults
+    "B9",  # flake8-bugbear opiniated warnings
+    "BLE",  # flake8-blind-except
+    "C4",  # flake8-comprehensions
+    "C9",  # mccabe
+    "E",  # pycodestyle errors
+    "F",  # pyflakes
+    "I",  # isort
+    "RUF",  # ruff rules
+    "TID", # flake8-tidy-imports
+    "UP",  # pyupgrade
+    "W",  # pycodestyle warnings
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 18
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+
+[tool.ruff.format]
+# default formatting is just fine
 
 [tool.mypy]
 warn_unused_configs = true


### PR DESCRIPTION
**GEOPY-1712 - disable RUF005 as it is wrong with numpy array**
