### PR TITLE
GEOPY-1862: for pypi, use dedicated package.rst as long description (readme field) instead of README.rst

### DIFF
--- a/package.rst
+++ b/package.rst
@@ -1,0 +1,62 @@
+curve-apps:
+=========================================================================
+The **curve-apps** library offers tools for the creation and manipulation of curve objects using various Python libraries and `geoh5py <https://mirageoscience-geoh5py.readthedocs-hosted.com/>`_.
+
+Installation
+^^^^^^^^^^^^
+**curve-apps** is currently written for Python 3.10 or higher.
+
+Install **curve-apps** from PyPI::
+
+    $ pip install curve-apps
+
+
+Feedback
+^^^^^^^^
+Have comments or suggestions? Submit feedback.
+All the content can be found on the github_ repository.
+
+.. _github: https://github.com/MiraGeoscience/curve-apps
+
+
+Visit `Mira Geoscience website <https://mirageoscience.com/>`_ to learn more about our products
+and services.
+
+
+License
+^^^^^^^
+MIT License
+
+Copyright (c) 2023-2025 Mira Geoscience
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Third Party Software
+^^^^^^^^^^^^^^^^^^^^
+The curve-apps Software may provide links to third party libraries or code (collectively “Third Party Software”)
+to implement various functions. Third Party Software does not comprise part of the Software.
+The use of Third Party Software is governed by the terms of such software license(s).
+Third Party Software notices and/or additional terms and conditions are located in the
+`THIRD_PARTY_SOFTWARE.rst`_ file.
+
+.. _THIRD_PARTY_SOFTWARE.rst: ./docs/source/THIRD_PARTY_SOFTWARE.rst
+
+Copyright
+^^^^^^^^^
+Copyright (c) 2024 Mira Geoscience Ltd.

--- a/package.rst
+++ b/package.rst
@@ -1,5 +1,5 @@
-curve-apps:
-=========================================================================
+curve-apps
+==========
 The **curve-apps** library offers tools for the creation and manipulation of curve objects using various Python libraries and `geoh5py <https://mirageoscience-geoh5py.readthedocs-hosted.com/>`_.
 
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/MiraGeoscience/curve-apps"
 readme = "package.rst"
 documentation  = "https://mirageoscience-curve-apps.readthedocs-hosted.com/"
 homepage = "https://www.mirageoscience.com/mining-industry-software/python-integration/"
-readme = "README.rst"
 packages = [
      { include = "curve_apps" },
      { include = "curve_apps-assets" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,11 @@
 name = "curve-apps"
 version = "0.3.0-alpha.1"
 license = "MIT"
-description = "Find edges on 2D grids or vertices."
+description = "Applications for the creation and manipulation of curve objects stored in geoh5 format."
 authors = ["Mira Geoscience <support@mirageoscience.com>"]
 maintainers = ["Dominique Fournier <dominiquef@mirageoscience.com>"]
 repository = "https://github.com/MiraGeoscience/curve-apps"
+readme = "package.rst"
 documentation  = "https://mirageoscience-curve-apps.readthedocs-hosted.com/"
 homepage = "https://www.mirageoscience.com/mining-industry-software/python-integration/"
 readme = "README.rst"


### PR DESCRIPTION
**GEOPY-1862 - for pypi, use dedicated package.rst as long description (readme field) instead of README.rst**
