### PR TITLE
DEVOPS-922: fixup: dask-core only in conda package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+/output
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -38,7 +38,7 @@ requirements:
     - scikit-image >=0.25.2, <0.26.dev
     - scipy >=1.14.0, <1.15.dev
     - tqdm >=4.66.1, <5.0.dev
-    - dask >=2025.3, <2025.4.dev
+    - dask-core >=2025.3, <2025.4.dev
     # Dash and related dependencies
     - dash >=3.0.4, 3.*
     - dash-ag-grid >=32.3.1, 32.*
@@ -55,6 +55,7 @@ tests:
         - curve_apps
         - curve_apps._version
         - curve_apps.peak_finder
+        - dask
   - script:
       - pytest --ignore=tests/version_test.py
     requirements:

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -64,6 +64,9 @@ tests:
     files:
       source:
         - tests/
+  - package_contents:
+      files:
+        - curve_apps/_version.py
 
 about:
   summary: Auto-detection of trends and edges in geoscientific data.

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -55,9 +55,9 @@ requirements:
 tests:
   - python:
       imports:
-        - curve_apps
-        - curve_apps._version
-        - curve_apps.peak_finder
+        - ${{ module_name }}
+        - ${{ module_name }}._version
+        - ${{ module_name }}.peak_finder
         - dask
   - script:
       - pytest --ignore=tests/version_test.py
@@ -69,7 +69,7 @@ tests:
         - tests/
   - package_contents:
       files:
-        - curve_apps/_version.py
+        - ${{ module_name }}/_version.py
 
 about:
   summary: Auto-detection of trends and edges in geoscientific data.

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -20,8 +20,6 @@ build:
   number: 0
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  always_include_files:
-    - ${{ module_name }}/_version.py
 
 requirements:
   host:

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -4,6 +4,7 @@ context:
   name: "curve-apps"
   version: "0.0.0.dev0"  # This will be replaced by the actual version in the build process
   python_min: "3.10"
+  module_name: ${{ name|lower|replace("-", "_") }}
 
 package:
   name: ${{ name|lower }}
@@ -19,6 +20,8 @@ build:
   number: 0
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  always_include_files:
+    - ${{ module_name }}/_version.py
 
 requirements:
   host:

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -69,7 +69,7 @@ tests:
         - tests/
   - package_contents:
       files:
-        - ${{ module_name }}/_version.py
+        - site-packages/${{ module_name }}/_version.py
 
 about:
   summary: Auto-detection of trends and edges in geoscientific data.


### PR DESCRIPTION
**DEVOPS-922 - build a Python environment for Analyst 4.7 development**
