### PR TITLE
DEVOPS-922: fix URL for peak finder doc

### DIFF
--- a/curve_apps-assets/uijson/peak_finder.ui.json
+++ b/curve_apps-assets/uijson/peak_finder.ui.json
@@ -2,7 +2,7 @@
     "version": "0.2.1-alpha.3",
     "title": "Peak Finder",
     "icon": "profile_drag_single",
-    "documentation": "https://mirageoscience-peak-finder-app.readthedocs-hosted.com/en/latest/",
+    "documentation": "https://mirageoscience-curve-apps.readthedocs-hosted.com/en/latest/peak-finder/peak_finder.html",
     "conda_environment": "curve_apps",
     "run_command": "curve_apps.peak_finder.application",
     "geoh5": "",


### PR DESCRIPTION
**DEVOPS-922 - build a Python environment for Analyst 4.7 development**
