### PR TITLE
GEOPY-2704: fix label capitalization

### DIFF
--- a/curve_apps-assets/uijson/contours.ui.json
+++ b/curve_apps-assets/uijson/contours.ui.json
@@ -59,14 +59,14 @@
     "fixed_contours": {
         "group": "Contours",
         "main": true,
-        "label": "Fixed Contours",
+        "label": "Fixed contours",
         "value": "0",
         "optional": true,
         "enabled": false
     },
     "max_distance": {
         "enabled": true,
-        "label": "Max Interpolation Distance (m)",
+        "label": "Max interpolation distance (m)",
         "main": true,
         "value": 500.0
     },

--- a/curve_apps-assets/uijson/edge_detection.ui.json
+++ b/curve_apps-assets/uijson/edge_detection.ui.json
@@ -72,7 +72,7 @@
         "main": true,
         "optional": true,
         "enabled": false,
-        "label": "Window Size (pixels)",
+        "label": "Window size (pixels)",
         "min": 16,
         "max": 512,
         "value": 64,
@@ -83,7 +83,7 @@
         "main": true,
         "optional": true,
         "enabled": false,
-        "label": "Merge Length (m)",
+        "label": "Merge length (m)",
         "min": 0,
         "value": 100.0,
         "tooltip": "If the distance between two nodes is less than this value, the nodes will be merged"

--- a/curve_apps-assets/uijson/peak_finder.ui.json
+++ b/curve_apps-assets/uijson/peak_finder.ui.json
@@ -114,7 +114,7 @@
         "enabled": true,
         "main": true,
         "group": "Python run preferences",
-        "label": "Save As",
+        "label": "Save as",
         "value": "Peak Finder",
         "visible": false
     },


### PR DESCRIPTION
**GEOPY-2704 - wrong capitalisation in labels**
