### PR TITLE
DEVOPS-1066: ci: add dependabot groups for MiraGeoscience/CI-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 4
+    groups:
+      github-actions:
+        patterns:
+          - actions/*
+      mirageo-ci-actions:
+        patterns:
+          - MiraGeoscience/CI-tools/.github/actions/*
+          - MiraGeoscience/CI-tools/.github/workflows/*


### PR DESCRIPTION
**DEVOPS-1066 - use CI-tools v3 in all the repos**
## Summary

Add `groups` configuration to `.github/dependabot.yml` to group all MiraGeoscience/CI-tools workflow and action bumps into a single dependabot PR, instead of creating one PR per file.

### Changes

- Added `github-actions` group for `actions/*` patterns
- Added `mirageo-ci-actions` group for `MiraGeoscience/CI-tools/.github/actions/*` and `MiraGeoscience/CI-tools/.github/workflows/*` patterns

---
*This PR was created by GitHub Copilot as part of DEVOPS-1066.*