### PR TITLE
GEOPY-2998: Update docs with release notes from GA 4.8 release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,30 +4,30 @@ Release Notes
 Release 0.4.0 (2026-06-04)
 --------------------------
 
-- GEOPY-2588: Add strike angle to output metrics
-- GEOPY-2741: Continue update to Python 3.12
-- GEOPY-1513: Add check for number of points before Delaunay crashes on trend lines
-- GEOPY-2608: Ignore segments of zero length to prevent warning from numpy
-- GEOPY-2759: have consistency in output labels: name, vs data name vs data group name
-- GEOPY-2745: Refresh screenshots of UIJsons in docs
+- Add strike angle to output metrics
+- Continue update to Python 3.12
+- Add check for number of points before Delaunay crashes on trend lines
+- Ignore segments of zero length to prevent warning from numpy
+- Have consistency in output labels: name, vs data name vs data group name
+- Refresh screenshots of UIJsons in docs
 
 
 Release 0.3.0 (2026-01-09)
 --------------------------
 
-- GEOPY-2491: Migrate peak-finder to curve-apps
+- Migrate peak-finder to curve-apps
 
 
 Release 0.2.0 (2025-02-07)
 --------------------------
 
-- GEOPY-1484: Replace geoapps-edge detection code for curve-apps.edge_detection
-- GEOPY-1529: Freeze parameters and update InputFile data on BaseData construction
-- GEOPY-1527: Make the canny add_data optional on get_edges method
-- GEOPY-761: Move Contouring app to curve-apps repo
-- GEOPY-1551: Use scikit-image.measure instead of matplotlib contours
-- GEOPY-1582: Formalize out_group as empty string or UIJsonGroup selector
-- GEOPY-1860: do not include top level files in wheels
+- Replace geoapps-edge detection code for curve-apps.edge_detection
+- Freeze parameters and update InputFile data on BaseData construction
+- Make the canny add_data optional on get_edges method
+- Move Contouring app to curve-apps repo
+- Use scikit-image.measure instead of matplotlib contours
+- Formalize out_group as empty string or UIJsonGroup selector
+- Do not include top level files in wheels
 
 Release 0.1.0 (2024-04-17)
 --------------------------
@@ -37,8 +37,8 @@ Release 0.1.0 (2024-04-17)
 New features
 ^^^^^^^^^^^^
 
-- GEOPY-292: Add metrics to edge detection.
-- GEOPY-768: Migration of Edge Detection application from MiraGeoscience/geoapps.git
-- GEOPY-1310: Add Trend Line application for detection lines from point data.
-- GEOPY-1348: Add azimuth based filters on Trend Lines
-- GEOPY-1400: Create documentation
+- Add metrics to edge detection.
+- Migration of Edge Detection application from MiraGeoscience/geoapps.git
+- Add Trend Line application for detection lines from point data.
+- Add azimuth based filters on Trend Lines
+- Create documentation

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,12 +11,10 @@ Release 0.4.0 (2026-06-04)
 - Have consistency in output labels: name, vs data name vs data group name
 - Refresh screenshots of UIJsons in docs
 
-
 Release 0.3.0 (2026-01-09)
 --------------------------
 
 - Migrate peak-finder to curve-apps
-
 
 Release 0.2.0 (2025-02-07)
 --------------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,8 +1,36 @@
 Release Notes
 =============
 
+Release 0.4.0 (2026-06-04)
+--------------------------
+
+- GEOPY-2588: Add strike angle to output metrics
+- GEOPY-2741: Continue update to Python 3.12
+- GEOPY-1513: Add check for number of points before Delaunay crashes on trend lines
+- GEOPY-2608: Ignore segments of zero length to prevent warning from numpy
+- GEOPY-2759: have consistency in output labels: name, vs data name vs data group name
+- GEOPY-2745: Refresh screenshots of UIJsons in docs
+
+
+Release 0.3.0 (2026-01-09)
+--------------------------
+
+- GEOPY-2491: Migrate peak-finder to curve-apps
+
+
+Release 0.2.0 (2025-02-07)
+--------------------------
+
+- GEOPY-1484: Replace geoapps-edge detection code for curve-apps.edge_detection
+- GEOPY-1529: Freeze parameters and update InputFile data on BaseData construction
+- GEOPY-1527: Make the canny add_data optional on get_edges method
+- GEOPY-761: Move Contouring app to curve-apps repo
+- GEOPY-1551: Use scikit-image.measure instead of matplotlib contours
+- GEOPY-1582: Formalize out_group as empty string or UIJsonGroup selector
+- GEOPY-1860: do not include top level files in wheels
+
 Release 0.1.0 (2024-04-17)
----------------------------
+--------------------------
 
 **(First release)**
 


### PR DESCRIPTION
**GEOPY-2998 - Update docs with release notes from GA 4.8 release**
